### PR TITLE
feat: Implement main calendar UI and Google Calendar integration

### DIFF
--- a/src/api/calendar.js
+++ b/src/api/calendar.js
@@ -1,0 +1,5 @@
+import apiClient from './client'
+
+export const getEvents = (date) => {
+  return apiClient.get(`/api/v1/calendar/events?date=${date}`)
+}

--- a/src/components/layout/DateNavigator.vue
+++ b/src/components/layout/DateNavigator.vue
@@ -9,25 +9,26 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { computed } from 'vue'
+import { useCalendarStore } from '@/stores/calendar'
 import { format, addDays } from 'date-fns'
 
-const currentDate = ref(new Date())
+const calendarStore = useCalendarStore()
 
 const formattedDate = computed(() => {
-  return format(currentDate.value, 'yyyy年MM月dd日(EEE)')
+  return format(calendarStore.currentDate, 'yyyy年MM月dd日(EEE)')
 })
 
 const prevDay = () => {
-  currentDate.value = addDays(currentDate.value, -1)
+  calendarStore.changeDate(addDays(calendarStore.currentDate, -1))
 }
 
 const nextDay = () => {
-  currentDate.value = addDays(currentDate.value, 1)
+  calendarStore.changeDate(addDays(calendarStore.currentDate, 1))
 }
 
 const today = () => {
-  currentDate.value = new Date()
+  calendarStore.changeDate(new Date())
 }
 </script>
 

--- a/src/components/layout/DateNavigator.vue
+++ b/src/components/layout/DateNavigator.vue
@@ -1,0 +1,54 @@
+<template lang="pug">
+  .date-navigator
+    button(@click="prevDay") <
+    span {{ formattedDate }}
+    button(@click="nextDay") >
+    button(@click="today") 今日
+    //- 日付ピッカーのプレースホルダー
+    button カレンダー
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import { format, addDays } from 'date-fns'
+
+const currentDate = ref(new Date())
+
+const formattedDate = computed(() => {
+  return format(currentDate.value, 'yyyy年MM月dd日(EEE)')
+})
+
+const prevDay = () => {
+  currentDate.value = addDays(currentDate.value, -1)
+}
+
+const nextDay = () => {
+  currentDate.value = addDays(currentDate.value, 1)
+}
+
+const today = () => {
+  currentDate.value = new Date()
+}
+</script>
+
+<style lang="sass" scoped>
+.date-navigator
+  display: flex
+  align-items: center
+  gap: 10px
+  margin-bottom: 20px
+
+  button
+    padding: 8px 12px
+    border: 1px solid #ccc
+    border-radius: 4px
+    background-color: #f0f0f0
+    cursor: pointer
+
+    &:hover
+      background-color: #e0e0e0
+
+  span
+    font-size: 1.2em
+    font-weight: bold
+</style>

--- a/src/components/specific/CalendarGrid.vue
+++ b/src/components/specific/CalendarGrid.vue
@@ -1,0 +1,45 @@
+<template lang="pug">
+  .calendar-grid
+    .time-axis
+      .time-label(v-for="hour in 24" :key="hour") {{ hour - 1 }}:00
+    .plan-column-wrapper
+      h3 予定 (Plan)
+      PlanColumn
+    .actual-column
+      h3 実績 (Actual)
+      //- ActualColumn コンポーネントをここに配置
+</template>
+
+<script setup>
+import PlanColumn from '@/components/specific/PlanColumn.vue'
+</script>
+
+<style lang="sass" scoped>
+.calendar-grid
+  display: grid
+  grid-template-columns: 60px 1fr 1fr // 時間軸、予定、実績
+  gap: 10px
+  border: 1px solid #eee
+  height: 800px // 仮の高さ
+  overflow-y: auto
+
+.time-axis
+  display: flex
+  flex-direction: column
+  .time-label
+    height: 33.33px // 15分単位で4行、1時間で4行 * 15分 = 60分
+    line-height: 33.33px
+    text-align: right
+    padding-right: 5px
+    border-bottom: 1px dotted #eee
+    &:last-child
+      border-bottom: none
+
+.plan-column-wrapper,
+.actual-column
+  border: 1px solid #eee
+  padding: 10px
+  h3
+    text-align: center
+    margin-bottom: 10px
+</style>

--- a/src/components/specific/PlanColumn.vue
+++ b/src/components/specific/PlanColumn.vue
@@ -1,0 +1,59 @@
+<template lang="pug">
+  .plan-column
+    .event-block(v-for="event in events" :key="event.id" :style="getEventStyle(event)")
+      | {{ event.summary }}
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { useCalendarStore } from '@/stores/calendar'
+import { parseISO, differenceInMinutes, setHours, setMinutes } from 'date-fns'
+
+const calendarStore = useCalendarStore()
+const events = computed(() => calendarStore.events)
+
+const getEventStyle = (event) => {
+  const start = parseISO(event.start.dateTime || event.start.date)
+  const end = parseISO(event.end.dateTime || event.end.date)
+
+  // 今日の0時0分を基準にする
+  const startOfDay = setMinutes(setHours(calendarStore.currentDate, 0), 0)
+
+  const top = differenceInMinutes(start, startOfDay) / 15 * 33.33 // 15分あたり33.33px
+  const height = differenceInMinutes(end, start) / 15 * 33.33
+
+  return {
+    top: `${top}px`,
+    height: `${height}px`,
+    backgroundColor: '#a7d9ff',
+    position: 'absolute',
+    width: 'calc(100% - 20px)',
+    left: '10px',
+    borderRadius: '4px',
+    padding: '5px',
+    overflow: 'hidden',
+    fontSize: '0.8em',
+    border: '1px solid #6cb7ed'
+  }
+}
+</script>
+
+<style lang="sass" scoped>
+.plan-column
+  position: relative
+  height: 100%
+  border: 1px solid #eee
+  padding: 10px
+  overflow-y: auto
+
+.event-block
+  background-color: #a7d9ff
+  border: 1px solid #6cb7ed
+  border-radius: 4px
+  padding: 5px
+  overflow: hidden
+  font-size: 0.8em
+  position: absolute
+  width: calc(100% - 20px)
+  left: 10px
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -2,6 +2,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 import HomeView from '../views/HomeView.vue'
 import LoginSuccess from '../views/LoginSuccess.vue'
 import LoginFailure from '../views/LoginFailure.vue'
+import MainView from '../views/MainView.vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -25,6 +26,11 @@ const router = createRouter({
       path: '/login/failure',
       name: 'LoginFailure',
       component: LoginFailure
+    },
+    {
+      path: '/main',
+      name: 'Main',
+      component: MainView
     }
   ]
 })

--- a/src/stores/calendar.js
+++ b/src/stores/calendar.js
@@ -1,0 +1,39 @@
+<script setup>
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { format } from 'date-fns'
+import * as calendarApi from '@/api/calendar'
+
+export const useCalendarStore = defineStore('calendar', () => {
+  const currentDate = ref(new Date())
+  const events = ref([])
+  const isLoading = ref(false)
+
+  const fetchEvents = async (date) => {
+    isLoading.value = true
+    try {
+      const formattedDate = format(date, 'yyyy-MM-dd')
+      const response = await calendarApi.getEvents(formattedDate)
+      events.value = response.data
+    } catch (error) {
+      console.error('Failed to fetch calendar events:', error)
+      events.value = []
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  const changeDate = (newDate) => {
+    currentDate.value = newDate
+    fetchEvents(newDate)
+  }
+
+  return {
+    currentDate,
+    events,
+    isLoading,
+    fetchEvents,
+    changeDate
+  }
+})
+</script>

--- a/src/views/AuthCallback.vue
+++ b/src/views/AuthCallback.vue
@@ -17,7 +17,7 @@ onMounted(async () => {
   if (code) {
     try {
       await authStore.handleAuthCallback(code)
-      router.push('/login/success')
+      router.push('/main')
     } catch (error) {
       console.error('Authentication failed:', error)
       router.push('/login/failure')

--- a/src/views/MainView.vue
+++ b/src/views/MainView.vue
@@ -6,7 +6,15 @@
 </template>
 
 <script setup>
+import { onMounted } from 'vue'
 import DateNavigator from '@/components/layout/DateNavigator.vue'
+import { useCalendarStore } from '@/stores/calendar'
+
+const calendarStore = useCalendarStore()
+
+onMounted(() => {
+  calendarStore.fetchEvents(calendarStore.currentDate)
+})
 </script>
 
 <style lang="sass" scoped>

--- a/src/views/MainView.vue
+++ b/src/views/MainView.vue
@@ -2,12 +2,13 @@
   .main-view
     h1 メイン画面
     DateNavigator
-    //- CalendarGrid
+    CalendarGrid
 </template>
 
 <script setup>
 import { onMounted } from 'vue'
 import DateNavigator from '@/components/layout/DateNavigator.vue'
+import CalendarGrid from '@/components/specific/CalendarGrid.vue'
 import { useCalendarStore } from '@/stores/calendar'
 
 const calendarStore = useCalendarStore()

--- a/src/views/MainView.vue
+++ b/src/views/MainView.vue
@@ -1,0 +1,18 @@
+<template lang="pug">
+  .main-view
+    h1 メイン画面
+    DateNavigator
+    //- CalendarGrid
+</template>
+
+<script setup>
+import DateNavigator from '@/components/layout/DateNavigator.vue'
+</script>
+
+<style lang="sass" scoped>
+.main-view
+  padding: 20px
+  h1
+    font-size: 2em
+    margin-bottom: 20px
+</style>


### PR DESCRIPTION
メイン画面の基本的な構造、日付ナビゲーション、カレンダーデータの状態管理、APIクライアント、そして予定表示のグリッドとカラムを実装しました。

主な変更点:
- `MainView.vue` の作成とルーティング設定
- `DateNavigator.vue` の作成と日付操作ロジック
- `calendar.js` Pinia ストアの作成とカレンダーイベント取得ロジック
- `api/calendar.js` の作成とバックエンドAPI呼び出し
- `CalendarGrid.vue` の作成と時間軸、予定・実績列のレイアウト
- `PlanColumn.vue` の作成と Google カレンダーイベントの表示